### PR TITLE
NoTicket: Use self-hosted runners instead of GitHub-hosted runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   assemble-library:
 
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, small]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/check-codestyle.yml
+++ b/.github/workflows/check-codestyle.yml
@@ -13,7 +13,7 @@ env:
 jobs:
   check-codestyle:
 
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, small]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   publish:
     name: Release build and publish
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, small]
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK 17


### PR DESCRIPTION
This pull request is to change the CI runner from GitHub-hosted runners (ubuntu-latest) to self-hosted runners. This change is necessary to improve the cost and control over our build environment. Please review our changes and provide your feedback.
